### PR TITLE
Update is_prime_ideal

### DIFF
--- a/lib/lib.g
+++ b/lib/lib.g
@@ -374,7 +374,7 @@ is_prime_ideal := function(obj, subset)
   l := ideals(obj);
 
   for x in l do
-    if not (IsSubset(x, subset) or IsSubset(dot(obj, x, subset), subset)) then
+    if not (IsSubset(subset, x) or IsSubset(subset, dot(obj, x, subset))) then
       return false;
     fi;
   od;


### PR DESCRIPTION
IsSubset was used incorrectly (the two inputs were switched).

From the GAP manual:
IsSubset( C1, C2 )	( operation )
IsSubset returns true if C2, which must be a collection, is a subset of C1, which also must be a collection, and false otherwise.